### PR TITLE
hide join-study is participant is initialised

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-    <widget android-versionCode="9" id="uk.ac.ucl.homeapp" ios-CFBundleIdentifier="uk.ac.ucl.homeapp" ios-CFBundleVersion="9" version="0.7.9" xmlns:android="http://schemas.android.com/apk/res/android">
+<widget android-versionCode="9" id="uk.ac.ucl.homeapp" ios-CFBundleIdentifier="uk.ac.ucl.homeapp" ios-CFBundleVersion="9" version="0.7.8" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>UCL HOME</name>
     <description>An application for analyzing health of migrants.</description>
     <author email="homeappstudy@ucl.ac.uk" href="http://radar-base.org/">RADAR-Base</author>

--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -206,10 +206,10 @@ export class ConfigService {
       .catch(() => false)
   }
 
-  checkParticipantEnrolled() {
+  checkParticipantEnrolled() : Promise<Boolean>{
     return this.subjectConfig
       .getParticipantLogin()
-      .then(participant => (participant ? participant : Promise.reject([])))
+      .then(participant => (!!participant))
   }
 
   updateConfigStateOnProtocolChange(protocol) {

--- a/src/app/pages/auth/components/welcome-page/welcome-page.component.html
+++ b/src/app/pages/auth/components/welcome-page/welcome-page.component.html
@@ -44,6 +44,7 @@
       {{ "WELCOME_SELECT_LANGUAGE" | translate }}
     </button>
     <button
+      *ngIf="showJoinStudy"
         ion-button
         class="bt bt--full"
         round

--- a/src/app/pages/auth/components/welcome-page/welcome-page.component.ts
+++ b/src/app/pages/auth/components/welcome-page/welcome-page.component.ts
@@ -44,6 +44,7 @@ export class WelcomePageComponent {
 
   settings: Settings = {}
   showLoading = false
+  showJoinStudy: Boolean = true
 
   constructor(
     private navCtrl: NavController,
@@ -56,10 +57,13 @@ export class WelcomePageComponent {
     private logger: LogService,
     private config: ConfigService,
     private authConfig: AuthConfigService,
-  ) {}
+  ) {
+    this.loadJoinStudy()
+  }
 
   ionViewDidLoad() {
     this.localization.update().then(lang => (this.language = lang))
+    this.loadJoinStudy()
   }
 
   showSelectLanguage() {
@@ -177,4 +181,10 @@ export class WelcomePageComponent {
     this.navCtrl.setRoot(SplashPageComponent)
   }
 
+  loadJoinStudy() {
+    this.config.checkParticipantEnrolled().then((result) => {
+      console.log("Participant enrolled: ", result)
+      this.showJoinStudy = !result
+    })
+  }
 }


### PR DESCRIPTION
hide join-study is participant is initialized
@peyman-mohtashami Hiding the buttons work fine. Although due to the hiding there is a gap (since the heights have hard-coded heights). I tried a few fixes. But I think we can only fix it using `flex-container`. Do you have a quick solution?
Otherwise, we can send a screenshot to UCL saying this is what they will get when button is hidden